### PR TITLE
Put flag images in a resource bundle

### DIFF
--- a/CountryPicker.podspec.json
+++ b/CountryPicker.podspec.json
@@ -15,5 +15,10 @@
     "ios": "4.3"
   },
   "source_files": "CountryPicker/CountryPicker.{h,m}",
-  "requires_arc": true
+  "requires_arc": true,
+  "resource_bundles": {
+    "CountryPicker": [
+      "Flags/*.png"
+    ]
+  }
 }

--- a/CountryPicker/CountryPicker.m
+++ b/CountryPicker/CountryPicker.m
@@ -239,8 +239,11 @@
     }
 
     ((UILabel *)[view viewWithTag:1]).text = [[self class] countryNames][(NSUInteger)row];
-    ((UIImageView *)[view viewWithTag:2]).image = [UIImage imageNamed:[[self class] countryCodes][(NSUInteger)row]];
-    
+    NSString *imagePath =
+            [NSString stringWithFormat:@"CountryPicker.bundle/%@", [[self class] countryCodes][(NSUInteger) row]];
+    ((UIImageView *)[view viewWithTag:2]).image = [UIImage imageNamed:imagePath];
+
+
     return view;
 }
 


### PR DESCRIPTION
Avoids conflicts with images in the target app or other pods.
Also, makes the flags work with cocoapods.
